### PR TITLE
Fix most recent commit logic bug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v1.0.2
+ - Fix most recent commit logic bug. (@esequiel.virtuoso)
+
 v1.0.1
  - Fix tag name conversion bug. (@esequiel.virtuoso)
 


### PR DESCRIPTION
## What?

Here goes your feature/bug-fix proposal

### Type of change?
- [x] [fix]: A bug fix

## Why?

Semantic release most recent commit function was comparing the wrong commits.
It was coincidentally working. 

## How?

Changing the logic of the function, comparing first element against every elements of commit history.

# Before submitting a PR please make sure to check if:

- [x] The code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] The changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
