### PR TITLE
Add feature to allow specifying version upgrade type on arguments list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v1.1.0
+ - Add `upgrade-type` argument option to allow manually specifying version type upgrade (@esequiel.virtuoso)
+
 v1.0.5
  - Fix isSetNewVersion function logic (@esequiel.virtuoso)
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,30 @@ setup(
 )
 ```
 
+### Upgrade specific type
+
+Moreover, semantic release allows us to set a specific part of the version with the argument `upgrade-type` that can be set as `major`, `minor`, or `patch` as follows.
+
+```yaml
+stages:
+  - semantic-release
+
+semantic-release:
+    stage: semantic-release
+    only:
+        refs:
+            - master
+    before_script: 
+        - docker pull registry.com/dataplatform/semantic-release:latest
+    script:
+        - docker run registry.com/dataplatform/semantic-release:latest up -upgrade-type major -git-host ${CI_SERVER_HOST} -git-group ${CI_PROJECT_NAMESPACE} -git-project ${CI_PROJECT_NAME} -username ${PPD2_USERNAME} -password ${PPD2_ACCESS_TOKEN}
+
+```
+
+- If the current version is `1.2.3` and you set `upgrade-type` as `major` the new version will be `2.0.0`;
+- If the current version is `1.2.3` and you set `upgrade-type` as `minor` the new version will be `1.3.0`;
+- If the current version is `1.2.3` and you set `upgrade-type` as `patch` the new version will be `1.2.4`;
+
  ### If you need more information about the semantic release CLI usage you can run the following command.
 
 ```

--- a/cmd/semantic-release/semantic-release.go
+++ b/cmd/semantic-release/semantic-release.go
@@ -41,6 +41,7 @@ func main() {
 	groupName := upgradeVersionCmd.String("git-group", "", "Git group name. (required)")
 	projectName := upgradeVersionCmd.String("git-project", "", "Git project name. (required)")
 	upgradePyFile := upgradeVersionCmd.Bool("setup-py", false, "Upgrade version in setup.py file. (default false)")
+	upgradeType := upgradeVersionCmd.String("upgrade-type", "", "Version to upgrade. I.e.: major, minor, patch.")
 	username := upgradeVersionCmd.String("username", "", "Git username. (required)")
 	password := upgradeVersionCmd.String("password", "", "Git password. (required)")
 	logLevel := upgradeVersionCmd.String("log-level", "debug", "Log level.")
@@ -67,7 +68,7 @@ func main() {
 	case "up":
 		logger.Info(colorYellow + "\nSemantic Version just started the process...\n\n" + colorReset)
 
-		semantic := newSemantic(logger, upgradeVersionCmd, gitHost, groupName, projectName, username, password, upgradePyFile)
+		semantic := newSemantic(logger, upgradeVersionCmd, gitHost, groupName, projectName, username, password, upgradePyFile, *upgradeType)
 
 		if err := semantic.GenerateNewRelease(); err != nil {
 			logger.Error(err.Error())
@@ -180,7 +181,7 @@ func printCommitMessageExample() {
 	fmt.Println("\n\tNote: The maximum number of characters is 150. If the commit subject exceeds it, it will be cut, keeping only the first 150 characters.")
 }
 
-func newSemantic(logger *log.Log, upgradeVersionCmd *flag.FlagSet, gitHost, groupName, projectName, username, password *string, upgradePyFile *bool) *semantic.Semantic {
+func newSemantic(logger *log.Log, upgradeVersionCmd *flag.FlagSet, gitHost, groupName, projectName, username, password *string, upgradePyFile *bool, upgradeType string) *semantic.Semantic {
 
 	validateIncomingParams(logger, upgradeVersionCmd, gitHost, groupName, projectName, username, password, upgradePyFile)
 
@@ -197,5 +198,5 @@ func newSemantic(logger *log.Log, upgradeVersionCmd *flag.FlagSet, gitHost, grou
 
 	versionControl := v.NewVersionControl(logger, timer.PrintElapsedTime)
 
-	return semantic.New(logger, repositoryRootPath, addFilesToUpgradeList(upgradePyFile, repositoryRootPath), repoVersionControl, filesVersionControl, versionControl)
+	return semantic.New(logger, repositoryRootPath, addFilesToUpgradeList(upgradePyFile, repositoryRootPath), repoVersionControl, filesVersionControl, versionControl, upgradeType)
 }

--- a/src/files/mock/CHANGELOG_MOCK.md
+++ b/src/files/mock/CHANGELOG_MOCK.md
@@ -8,6 +8,26 @@
 - feat - [b25a9af](https://gitlab.com/dataplatform/test/commit/b25a9af78c30de0d03ca2ee6d18c66bbc4804395): This is a short message to write to changelog.md file. (@admin)
 ---
 
+
+## v1.1.0
+- feat - [b25a9af](https://gitlab.com/dataplatform/test/commit/b25a9af78c30de0d03ca2ee6d18c66bbc4804395): This is a long message to write to changelog.md file. bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo ... (@admin)
+---
+
+
+## v1.1.0
+- feat - [b25a9af](https://gitlab.com/dataplatform/test/commit/b25a9af78c30de0d03ca2ee6d18c66bbc4804395): This is a short message to write to changelog.md file. (@admin)
+---
+
+
+## v1.1.0
+- feat - [b25a9af](https://gitlab.com/dataplatform/test/commit/b25a9af78c30de0d03ca2ee6d18c66bbc4804395): This is a long message to write to changelog.md file. bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo ... (@admin)
+---
+
+
+## v1.1.0
+- feat - [b25a9af](https://gitlab.com/dataplatform/test/commit/b25a9af78c30de0d03ca2ee6d18c66bbc4804395): This is a short message to write to changelog.md file. (@admin)
+---
+
 ## v1.0.1
 - fix - The new commit message:  (user.name@neoway.com.br)
 ---

--- a/src/semantic/semantic_test.go
+++ b/src/semantic/semantic_test.go
@@ -55,7 +55,7 @@ func (v *VersionControlMock) GetCommitChangeType(commitMessage string) (string, 
 	return v.commitChangeType, v.errCommitChangeType
 }
 
-func (v *VersionControlMock) GetNewVersion(commitMessage string, currentVersion string) (string, error) {
+func (v *VersionControlMock) GetNewVersion(commitMessage string, currentVersion string, upgradeType string) (string, error) {
 	return v.newVersion, v.errGetNewVersion
 }
 
@@ -93,7 +93,8 @@ func (f *fixture) NewSemantic() *semantic.Semantic {
 		errors.New("error while getting new log")
 	}
 
-	return semantic.New(logger, f.rootPath, f.filesToUpdateVariable, f.repoVersionMock, f.filesVersionMock, f.versionControlMock)
+	version := ""
+	return semantic.New(logger, f.rootPath, f.filesToUpdateVariable, f.repoVersionMock, f.filesVersionMock, f.versionControlMock, version)
 }
 
 type upgradeFilesMock struct {

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -16,10 +16,10 @@ const (
 )
 
 var (
-	commitChangeTypes             = []string{"build", "ci", "docs", "fix", "feat", "perf", "refactor", "style", "test", "breaking change", "breaking changes", "skip", "skip versioning", "skip v"}
-	commitChangeTypesMajorUpgrade = []string{"breaking change", "breaking changes"}
-	commitChangeTypesMinorUpgrade = []string{"feat"}
-	commitChangeTypePatchUpgrade  = []string{"build", "ci", "docs", "fix", "perf", "refactor", "style", "test"}
+	commitChangeTypes             = []string{"build", "ci", "docs", "fix", "feat", "perf", "refactor", "style", "test", "breaking change", "breaking changes", "skip", "skip versioning", "skip v", "major", "minor", "patch"}
+	commitChangeTypesMajorUpgrade = []string{"breaking change", "breaking changes", "major"}
+	commitChangeTypesMinorUpgrade = []string{"feat", "minor"}
+	commitChangeTypePatchUpgrade  = []string{"build", "ci", "docs", "fix", "perf", "refactor", "style", "test", "patch"}
 	commitTypeSkipVersioning      = []string{"skip", "skip versioning", "skip v"}
 )
 
@@ -37,14 +37,17 @@ type VersionControl struct {
 
 // splitVersionMajorMinorPatch get a string version, split it and return a map of int values
 // Args:
-// 		version (string): Version to be splited. I.e: 2.1.1
-// Returns:
-// 		Success:
-// 		It returns a map of int values
-//      I.e.: map[MAJOR:2 MINOR:1 PATCH:1]
 //
-// 		Otherwise:
-// 			error
+//	version (string): Version to be splited. I.e: 2.1.1
+//
+// Returns:
+//
+//			Success:
+//			It returns a map of int values
+//	     I.e.: map[MAJOR:2 MINOR:1 PATCH:1]
+//
+//			Otherwise:
+//				error
 func (v *VersionControl) splitVersionMajorMinorPatch(version string) (map[string]int, error) {
 	splitedVersion := strings.Split(version, ".")
 
@@ -74,12 +77,15 @@ func (v *VersionControl) splitVersionMajorMinorPatch(version string) (map[string
 // getUpgradeType defines where to update the current version
 // MAJOR.MINOR.PATCH. I.e: 2.1.1
 // Args:
-// 		commitChangeType (string): Type of changes within the commit. I.e.: fix, feat, doc, etc. Take a look at CommitChangeTypes variable.
+//
+//	commitChangeType (string): Type of changes within the commit. I.e.: fix, feat, doc, etc. Take a look at CommitChangeTypes variable.
+//
 // Returns:
-// 		MAJOR: if the commit type is in CommitChangeTypesMajorUpgrade slice
-// 		MINOR: if the commit type is in CommitChangeTypesMinorUpgrade slice
-// 		PATCH: if the commit type is in CommitChangeTypePatchUpgrade slice
-// 		Otherwise, it returns an error
+//
+//	MAJOR: if the commit type is in CommitChangeTypesMajorUpgrade slice
+//	MINOR: if the commit type is in CommitChangeTypesMinorUpgrade slice
+//	PATCH: if the commit type is in CommitChangeTypePatchUpgrade slice
+//	Otherwise, it returns an error
 func (v *VersionControl) getUpgradeType(commitChangeType string) (string, error) {
 	if v.hasStringInSlice(commitChangeType, commitChangeTypesMajorUpgrade) {
 		return major, nil
@@ -93,16 +99,19 @@ func (v *VersionControl) getUpgradeType(commitChangeType string) (string, error)
 
 // upgradeVersion upgrade the current version based on the upgradeType.
 // Args:
-// 		upgradeType (string): MAJOR, MINOR or PATCH.
-// 		currentMajor (string): Current release major version. I.e.: >2<.1.1.
-// 		currentMinor (string): Current release minor version. I.e.: 2.>1<.1.
-// 		currentPatch (string): Current release patch version. I.e.: 2.1.>1<.
+//
+//	upgradeType (string): MAJOR, MINOR or PATCH.
+//	currentMajor (string): Current release major version. I.e.: >2<.1.1.
+//	currentMinor (string): Current release minor version. I.e.: 2.>1<.1.
+//	currentPatch (string): Current release patch version. I.e.: 2.1.>1<.
+//
 // Returns:
-// 		It will return a string with the new version.
-// 		I.e.:
-// 		1 - If the current version is 2.1.1 and the update type is MAJOR it will return 3.0.0
-// 		2 - If the current version is 2.1.1 and the update type is MINOR it will return 2.2.0
-// 		1 - If the current version is 2.1.1 and the update type is PATCH it will return 2.1.2
+//
+//	It will return a string with the new version.
+//	I.e.:
+//	1 - If the current version is 2.1.1 and the update type is MAJOR it will return 3.0.0
+//	2 - If the current version is 2.1.1 and the update type is MINOR it will return 2.2.0
+//	1 - If the current version is 2.1.1 and the update type is PATCH it will return 2.1.2
 func (v *VersionControl) upgradeVersion(upgradeType string, currentMajor, currentMinor, currentPatch int) string {
 	versionPattern := "%d.%d.%d"
 	var newVersion string
@@ -131,22 +140,31 @@ func (v *VersionControl) isFirstVersion(version string) bool {
 // GetNewVersion upgrade the current version based on the commitChangeType.
 // It calls the getUpgradeType function to define where to upgrade the version (MAJOR.MINOR.PATCH).
 // Args:
-// 		commitMessage (string): The commit message.
-// 		currentVersion (string): Current release version. I.e.: 2.1.1.
+//
+//	commitMessage (string): The commit message.
+//	currentVersion (string): Current release version. I.e.: 2.1.1.
+//
 // Returns:
-// 		string: It will return a string with the new version.
-// 			I.e.:
-// 			1 - If the current version is 2.1.1 and the update type is MAJOR it will return 3.0.0
-// 			2 - If the current version is 2.1.1 and the update type is MINOR it will return 2.2.0
-// 			1 - If the current version is 2.1.1 and the update type is PATCH it will return 2.1.2
-// 		error: It returns an error when something wrong happen.
-func (v *VersionControl) GetNewVersion(commitMessage string, currentVersion string) (string, error) {
+//
+//	string: It will return a string with the new version.
+//		I.e.:
+//		1 - If the current version is 2.1.1 and the update type is MAJOR it will return 3.0.0
+//		2 - If the current version is 2.1.1 and the update type is MINOR it will return 2.2.0
+//		1 - If the current version is 2.1.1 and the update type is PATCH it will return 2.1.2
+//	error: It returns an error when something wrong happen.
+func (v *VersionControl) GetNewVersion(commitMessage string, currentVersion string, upgradeType string) (string, error) {
 	defer v.printElapsedTime("GetNewVersion")()
 	v.log.Info("generating new version from %s", currentVersion)
 
-	commitChangeType, err := v.GetCommitChangeType(commitMessage)
-	if err != nil {
-		return "", fmt.Errorf("error while finding commit change type within commit message due to: %w", err)
+	var commitChangeType string
+	var err error
+	if upgradeType == "" {
+		commitChangeType, err = v.GetCommitChangeType(commitMessage)
+		if err != nil {
+			return "", fmt.Errorf("error while finding commit change type within commit message due to: %w", err)
+		}
+	} else {
+		commitChangeType = upgradeType
 	}
 
 	curVersion, err := v.splitVersionMajorMinorPatch(currentVersion)
@@ -157,12 +175,12 @@ func (v *VersionControl) GetNewVersion(commitMessage string, currentVersion stri
 	currentMinor := curVersion[minor]
 	currentPatch := curVersion[patch]
 
-	upgradeType, err := v.getUpgradeType(commitChangeType)
+	commitUpgradeType, err := v.getUpgradeType(commitChangeType)
 	if err != nil {
 		return "", fmt.Errorf("error while getting upgrade type due to: %w", err)
 	}
 
-	newVersion := v.upgradeVersion(upgradeType, currentMajor, currentMinor, currentPatch)
+	newVersion := v.upgradeVersion(commitUpgradeType, currentMajor, currentMinor, currentPatch)
 	if v.isFirstVersion(newVersion) {
 		return "1.0.0", nil
 	}
@@ -172,8 +190,10 @@ func (v *VersionControl) GetNewVersion(commitMessage string, currentVersion stri
 
 // GetCommitChangeType get the commit type from Message
 // I.e.:
-//       type: [fix]
-//       message: Commit subject here.
+//
+//	type: [fix]
+//	message: Commit subject here.
+//
 // Output: fix
 func (v *VersionControl) GetCommitChangeType(commitMessage string) (string, error) {
 	v.log.Info("getting commit type from message %s", commitMessage)
@@ -192,10 +212,13 @@ func (v *VersionControl) GetCommitChangeType(commitMessage string) (string, erro
 // hasStringInSlice aims to verify if a string is inside a slice of strings.
 // It requires a full match.
 // Args:
-// 		value (string): String value to find.
-// 		slice ([]string): Slice containing strings.
+//
+//	value (string): String value to find.
+//	slice ([]string): Slice containing strings.
+//
 // Returns:
-// 		bool: True when found, otherwise false.
+//
+//	bool: True when found, otherwise false.
 func (v *VersionControl) hasStringInSlice(value string, slice []string) bool {
 	for i := range slice {
 		if slice[i] == value {
@@ -207,7 +230,9 @@ func (v *VersionControl) hasStringInSlice(value string, slice []string) bool {
 
 // MustSkip compare commit type with skip types (CommitTypeSkipVersioning) to avoid upgrading version.
 // I.e.:
-//       commitChangeType: [skip]
+//
+//	commitChangeType: [skip]
+//
 // Output: true
 func (v *VersionControl) MustSkipVersioning(commitMessage string) bool {
 	commitChangeType, err := v.GetCommitChangeType(commitMessage)

--- a/src/version/version_test.go
+++ b/src/version/version_test.go
@@ -34,7 +34,8 @@ func PrintElapsedTimeMock(what string) func() {
 
 func TestGetNewVersionGetCommitChangeTypeFromMessageError(t *testing.T) {
 	f := setup()
-	actualVersion, actualErr := f.versionControl.GetNewVersion("", "")
+	upgradeType := ""
+	actualVersion, actualErr := f.versionControl.GetNewVersion("", "", upgradeType)
 	tests.AssertError(t, actualErr)
 	tests.AssertEqualValues(t, "error while finding commit change type within commit message due to: change type not found", actualErr.Error())
 	tests.AssertEmpty(t, actualVersion)
@@ -42,7 +43,8 @@ func TestGetNewVersionGetCommitChangeTypeFromMessageError(t *testing.T) {
 
 func TestGetNewVersionSplitVersionMajorMinorPatchError(t *testing.T) {
 	f := setup()
-	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[feat]", "1.0.a")
+	upgradeType := ""
+	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[feat]", "1.0.a", upgradeType)
 	tests.AssertError(t, actualErr)
 	tests.AssertEqualValues(t, "error while spliting version into MAJOR.MINOR.PATCH due to: could not convert a to int", actualErr.Error())
 	tests.AssertEmpty(t, actualVersion)
@@ -50,7 +52,8 @@ func TestGetNewVersionSplitVersionMajorMinorPatchError(t *testing.T) {
 
 func TestGetNewVersionSplitVersionPathernError(t *testing.T) {
 	f := setup()
-	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[feat]", "1.0")
+	upgradeType := ""
+	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[feat]", "1.0", upgradeType)
 	tests.AssertError(t, actualErr)
 	tests.AssertEqualValues(t, "error while spliting version into MAJOR.MINOR.PATCH due to: version must follow the pattern major.minor.patch. I.e.: 1.0.0", actualErr.Error())
 	tests.AssertEmpty(t, actualVersion)
@@ -58,7 +61,8 @@ func TestGetNewVersionSplitVersionPathernError(t *testing.T) {
 
 func TestGetNewVersionGetUpgradeTypeError(t *testing.T) {
 	f := setup()
-	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[skip]", "1.0.0")
+	upgradeType := ""
+	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[skip]", "1.0.0", upgradeType)
 	tests.AssertError(t, actualErr)
 	tests.AssertEqualValues(t, "error while getting upgrade type due to: skip is an invalid upgrade change type", actualErr.Error())
 	tests.AssertEmpty(t, actualVersion)
@@ -66,21 +70,24 @@ func TestGetNewVersionGetUpgradeTypeError(t *testing.T) {
 
 func TestGetNewVersionMajorSuccess(t *testing.T) {
 	f := setup()
-	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[breaking change]", "1.0.0")
+	upgradeType := ""
+	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[breaking change]", "1.0.0", upgradeType)
 	tests.AssertNoError(t, actualErr)
 	tests.AssertEqualValues(t, "2.0.0", actualVersion)
 }
 
 func TestGetNewVersionMinorSuccess(t *testing.T) {
 	f := setup()
-	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[feat]", "1.0.0")
+	upgradeType := ""
+	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[feat]", "1.0.0", upgradeType)
 	tests.AssertNoError(t, actualErr)
 	tests.AssertEqualValues(t, "1.1.0", actualVersion)
 }
 
 func TestGetNewVersionPatchSuccess(t *testing.T) {
 	f := setup()
-	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[fix]", "1.0.0")
+	upgradeType := ""
+	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[fix]", "1.0.0", upgradeType)
 	tests.AssertNoError(t, actualErr)
 	tests.AssertEqualValues(t, "1.0.1", actualVersion)
 }
@@ -102,11 +109,36 @@ func TestMustSkipVersioningTrue(t *testing.T) {
 
 func TestGetNewVersionFirstVersionSuccess(t *testing.T) {
 	f := setup()
-	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[fix]", "0.0.0")
+	upgradeType := ""
+	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[fix]", "0.0.0", upgradeType)
 	tests.AssertNoError(t, actualErr)
 	tests.AssertEqualValues(t, "1.0.0", actualVersion)
 
-	actualVersion, actualErr = f.versionControl.GetNewVersion("type:[feat]", "0.0.0")
+	actualVersion, actualErr = f.versionControl.GetNewVersion("type:[feat]", "0.0.0", upgradeType)
 	tests.AssertNoError(t, actualErr)
 	tests.AssertEqualValues(t, "1.0.0", actualVersion)
+}
+
+func TestGetNewVersionSpecificPatchSuccess(t *testing.T) {
+	f := setup()
+	upgradeType := "patch"
+	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[feat]", "1.0.0", upgradeType)
+	tests.AssertNoError(t, actualErr)
+	tests.AssertEqualValues(t, "1.0.1", actualVersion)
+}
+
+func TestGetNewVersionSpecificMajorSuccess(t *testing.T) {
+	f := setup()
+	upgradeType := "major"
+	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[feat]", "1.0.0", upgradeType)
+	tests.AssertNoError(t, actualErr)
+	tests.AssertEqualValues(t, "2.0.0", actualVersion)
+}
+
+func TestGetNewVersionSpecificMinorSuccess(t *testing.T) {
+	f := setup()
+	upgradeType := "minor"
+	actualVersion, actualErr := f.versionControl.GetNewVersion("type:[fix]", "1.0.0", upgradeType)
+	tests.AssertNoError(t, actualErr)
+	tests.AssertEqualValues(t, "1.1.0", actualVersion)
 }


### PR DESCRIPTION
## What?

Add feature to allow specifying version upgrade type on arguments list.

### Type of change?

- [ ] [breaking change(s)]: Changes that will require other changes in dependant applications.
- [ ] [build]: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] [ci]: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] [docs]: Documentation only changes
- [x] [feat]: A new feature
- [ ] [fix]: A bug fix
- [ ] [perf]: A code change that improves performance
- [ ] [refactor]: A code change that neither fixes a bug nor adds a feature
- [ ] [style]: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] [test]: Adding missing tests or correcting existing tests

Note: Remove the non-checked options

## Why?

We need a way to make semantic release easier.

## How?

By adding a new feature to allow user to specify upgrade type (major, minor, patch).

## How has this been tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Benchmark tests


# Before submitting a PR please make sure to check if:

- [x] The code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] The changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and/or existing unit tests pass locally with my changes
- [x] New and/or existing integration tests pass locally with my changes
