### PR TITLE
fix(commit-lint): Fix IsValidMessage method to skip commit lint when …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+v2.0.1:
+ - Fix IsValidMessage method to skip commit lint when the message is a merge from master to a developer branch. (@esequiel.virtuoso)
+ - Add chore option. (@esequiel.virtuoso)
+
+v2.0.0:
+ - Change semantic-release message pattern to 'type(scope?): message here'. (@esequiel.virtuoso)
+
 v1.0.5
  - Fix isSetNewVersion function logic (@esequiel.virtuoso)
 

--- a/cmd/semantic-release/semantic-release.go
+++ b/cmd/semantic-release/semantic-release.go
@@ -183,6 +183,7 @@ func printCommitTypes() {
 	fmt.Println(colorYellow + "\t*         [refactor]" + colorReset + ": A code change that neither fixes a bug nor adds a feature")
 	fmt.Println(colorYellow + "\t*            [style]" + colorReset + ": Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)")
 	fmt.Println(colorYellow + "\t*             [test]" + colorReset + ": Adding missing tests or correcting existing tests")
+	fmt.Println(colorYellow + "\t*            [chore]" + colorReset + ": No production code change. It won't release a new version.")
 	fmt.Println(colorYellow + "\t*             [skip]" + colorReset + ": Skip versioning")
 	fmt.Println(colorYellow + "\t*               [bc]" + colorReset + ": Changes that will require other changes in dependant applications")
 	fmt.Println(colorYellow + "\t*         [breaking]" + colorReset + ": ||")

--- a/src/commit-message/commit_message_manager.go
+++ b/src/commit-message/commit_message_manager.go
@@ -75,7 +75,22 @@ func (f *CommitMessage) PrettifyCommitMessage(commitMessage string) (string, err
 	return f.upperFirstLetterOfSentence(message), nil
 }
 
+func isMergeMasterBranch(message string) bool {
+	splitedMessage := strings.Split(strings.ToLower(message), "\n")
+
+	for _, row := range splitedMessage {
+		if strings.Contains(row, "'origin/master' into") {
+			return true
+		}
+	}
+	return false
+}
+
 func (f *CommitMessage) IsValidMessage(message string) bool {
+	if isMergeMasterBranch(message) {
+		return true
+	}
+
 	index := strings.Index(message, ":")
 
 	if f.commitType.IndexNotFound(index) {

--- a/src/commit-message/commit_message_manager.go
+++ b/src/commit-message/commit_message_manager.go
@@ -75,7 +75,7 @@ func (f *CommitMessage) PrettifyCommitMessage(commitMessage string) (string, err
 	return f.upperFirstLetterOfSentence(message), nil
 }
 
-func isMergeMasterBranch(message string) bool {
+func isMergeMasterToBranch(message string) bool {
 	splitedMessage := strings.Split(strings.ToLower(message), "\n")
 
 	for _, row := range splitedMessage {
@@ -87,7 +87,7 @@ func isMergeMasterBranch(message string) bool {
 }
 
 func (f *CommitMessage) IsValidMessage(message string) bool {
-	if isMergeMasterBranch(message) {
+	if isMergeMasterToBranch(message) {
 		return true
 	}
 

--- a/src/commit-message/commit_message_manager_test.go
+++ b/src/commit-message/commit_message_manager_test.go
@@ -94,3 +94,10 @@ func TestIsValidMessageFalse(t *testing.T) {
 	actual = f.commitMessageManager.IsValidMessage(message)
 	tests.AssertFalse(t, actual)
 }
+
+func TestIsValidMessageMergeMasterBranchSuccess(t *testing.T) {
+	f := setup(t)
+	message := "first message row \n Merge remote-tracking branch 'origin/master' into something \n last message row"
+	actual := f.commitMessageManager.IsValidMessage(message)
+	tests.AssertTrue(t, actual)
+}

--- a/src/commit-type/commit_type.go
+++ b/src/commit-type/commit_type.go
@@ -15,7 +15,7 @@ type CommitType struct {
 }
 
 func (c *CommitType) GetAll() []string {
-	return []string{"build", "ci", "docs", "fix", "feat", "feature", "feature", "perf", "performance", "refactor", "style", "test", "bc", "breaking", "breaking change", "skip"}
+	return []string{"build", "ci", "docs", "fix", "feat", "feature", "feature", "perf", "performance", "refactor", "style", "test", "bc", "breaking", "breaking change", "chore", "skip"}
 }
 
 func (c *CommitType) GetMajorUpgrade() []string {
@@ -31,7 +31,7 @@ func (c *CommitType) GetPatchUpgrade() []string {
 }
 
 func (c *CommitType) GetSkipVersioning() []string {
-	return []string{"skip"}
+	return []string{"skip", "chore"}
 }
 
 func (c *CommitType) isValidCommitType(commitTypeScope string) bool {

--- a/src/commit-type/commit_type_test.go
+++ b/src/commit-type/commit_type_test.go
@@ -27,7 +27,7 @@ func setup(t *testing.T) *fixture {
 
 func TestGetAll(t *testing.T) {
 	f := setup(t)
-	expected := []string{"build", "ci", "docs", "fix", "feat", "feature", "feature", "perf", "performance", "refactor", "style", "test", "bc", "breaking", "breaking change", "skip"}
+	expected := []string{"build", "ci", "docs", "fix", "feat", "feature", "feature", "perf", "performance", "refactor", "style", "test", "bc", "breaking", "breaking change", "chore", "skip"}
 	actual := f.commitType.GetAll()
 
 	tests.AssertDeepEqualValues(t, expected, actual)
@@ -59,7 +59,7 @@ func TestGetPatchUpgrade(t *testing.T) {
 
 func TestGetSkipVersioning(t *testing.T) {
 	f := setup(t)
-	expected := []string{"skip"}
+	expected := []string{"skip", "chore"}
 	actual := f.commitType.GetSkipVersioning()
 
 	tests.AssertDeepEqualValues(t, expected, actual)


### PR DESCRIPTION
## What?

Here goes your feature/bug-fix proposal

### Type of change?

- [x] [fix]: A bug fix

## Why?

Avoid commit-lint breaking when it's a merge from the master to the developer branch.

## How?

Addin a new function to identify the merge action within the commit message.

## How has this been tested?

- [x] Unit tests

# Before submitting a PR please make sure to check if:

- [x] The code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] The changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and/or existing unit tests pass locally with my changes
- [x] New and/or existing integration tests pass locally with my changes
