### PR TITLE
fix: Fix IsValidMessage method adding a new exception for merge from master to the branch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v2.0.2:
+ - Fix IsValidMessage method adding a new exception for merge from master to the branch (@esequiel.virtuoso)
+
 v2.0.1:
  - Fix IsValidMessage method to skip commit lint when the message is a merge from master to a developer branch. (@esequiel.virtuoso)
  - Add chore option. (@esequiel.virtuoso)

--- a/src/commit-message/commit_message_manager.go
+++ b/src/commit-message/commit_message_manager.go
@@ -79,7 +79,7 @@ func isMergeMasterToBranch(message string) bool {
 	splitedMessage := strings.Split(strings.ToLower(message), "\n")
 
 	for _, row := range splitedMessage {
-		if strings.Contains(row, "'origin/master' into") {
+		if strings.Contains(row, "'origin/master' into") || strings.Contains(row, "merge branch 'master' into") {
 			return true
 		}
 	}

--- a/src/commit-message/commit_message_manager_test.go
+++ b/src/commit-message/commit_message_manager_test.go
@@ -100,4 +100,8 @@ func TestIsValidMessageMergeMasterBranchSuccess(t *testing.T) {
 	message := "first message row \n Merge remote-tracking branch 'origin/master' into something \n last message row"
 	actual := f.commitMessageManager.IsValidMessage(message)
 	tests.AssertTrue(t, actual)
+
+	message = "first message row \n Merge branch 'master' into something \n last message row"
+	actual = f.commitMessageManager.IsValidMessage(message)
+	tests.AssertTrue(t, actual)
 }


### PR DESCRIPTION
## What?

[Here goes your feature/bug-fix proposal](fix: Fix IsValidMessage method adding a new exception for merge from master to the branch.)

### Type of change?

- [x] [fix]: A bug fix

## Why?

Avoid commit-lint breaking when it's a merge from the master to the developer branch.

## How?

Addin a new function to identify the merge action within the commit message.

## How has this been tested?

- [x] Unit tests

# Before submitting a PR please make sure to check if:

- [x] The code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] The changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and/or existing unit tests pass locally with my changes
- [x] New and/or existing integration tests pass locally with my changes

