### PR TITLE
feat: add new merge master commit message to be validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 v2.0.3:
+ - Added a new commit message to be validated for merge from master to the branch (@artus.andermann)
+
+v2.0.3:
  - Fix IsValidMessage method adding a new exception for merge from master to the branch (@esequiel.virtuoso)
 
 v2.0.2:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-v2.0.3:
+v2.0.4:
  - Added a new commit message to be validated for merge from master to the branch (@artus.andermann)
 
 v2.0.3:

--- a/src/commit-message/commit_message_manager.go
+++ b/src/commit-message/commit_message_manager.go
@@ -3,6 +3,7 @@ package commitmessage
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -78,17 +79,34 @@ func (f *CommitMessage) PrettifyCommitMessage(commitMessage string) (string, err
 func isMergeMasterToBranch(message string) bool {
 	splitedMessage := strings.Split(strings.ToLower(message), "\n")
 
+	mergePatterns := []string{
+		"'origin/master' into",
+		"merge branches 'master' into",
+		"merge branch 'master' into",
+		"merge branch 'master' of",
+		"'origin/main' into",
+		"merge branch 'main' into",
+		"merge branch 'main' of",
+	}
+
+	mergeRegexPattern := `merge branches '.*' and 'master' of`
+	re := regexp.MustCompile(mergeRegexPattern)
+
 	for _, row := range splitedMessage {
 		lowerRow := strings.ToLower(row)
-		if strings.Contains(lowerRow, "'origin/master' into") ||
-			strings.Contains(lowerRow, "merge branch 'master' into") ||
-			strings.Contains(lowerRow, "merge branch 'master' of") ||
-			strings.Contains(lowerRow, "'origin/main' into") ||
-			strings.Contains(lowerRow, "merge branch 'main' into") ||
-			strings.Contains(lowerRow, "merge branch 'main' of") {
+
+		found := re.MatchString(lowerRow)
+		if found {
 			return true
 		}
+
+		for _, pattern := range mergePatterns {
+			if strings.Contains(lowerRow, pattern) {
+				return true
+			}
+		}
 	}
+
 	return false
 }
 

--- a/src/commit-message/commit_message_manager_test.go
+++ b/src/commit-message/commit_message_manager_test.go
@@ -59,6 +59,10 @@ func TestIsValidMessageSuccess(t *testing.T) {
 	actual := f.commitMessageManager.IsValidMessage(message)
 	tests.AssertTrue(t, actual)
 
+	message = "Merge branches 'sample-branch' and 'master' of ssh://gitlab.lalala/j/dv into sample-branch"
+	actual = f.commitMessageManager.IsValidMessage(message)
+	tests.AssertTrue(t, actual)
+
 	message = "feat(scope): This is a message"
 	actual = f.commitMessageManager.IsValidMessage(message)
 	tests.AssertTrue(t, actual)


### PR DESCRIPTION
## What?

I've already twice received a different automatic message pattern when merging the master branch into my developer branch.

The message is like this:

`Merge branches 'my-developer-branch' and 'master' of ssh://gitlab/.lalala/j/dv into my-developer-branch`

### Type of change?

- [ ] [breaking change(s)]: Changes that will require other changes in dependant applications.
- [ ] [build]: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] [ci]: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] [docs]: Documentation only changes
- [ X ] [feat]: A new feature
- [ ] [fix]: A bug fix
- [ ] [perf]: A code change that improves performance
- [ ] [refactor]: A code change that neither fixes a bug nor adds a feature
- [ ] [style]: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] [test]: Adding missing tests or correcting existing tests

## Why?

* The commit-lint stage breaks with this kind of unmapped message type.

* This automatic message doesn't appear in the `git log` or in the messages from `git rebase -i HEAD~<number of commits to fix>`. 

## How?

Apparently, this new type of message doesn't cause any type of modifications in the master branch.

## How has this been tested?

- [ X ] Unit tests
- [ ] Integration tests
- [ ] Benchmark tests


# Before submitting a PR please make sure to check if:

- [ ] The code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and/or existing unit tests pass locally with my changes
- [ ] New and/or existing integration tests pass locally with my changes
